### PR TITLE
Removed pom hierarchy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.bq.oss</groupId>
-        <artifactId>corbel-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
-    </parent>
-
     <groupId>com.bq.oss.corbel</groupId>
     <artifactId>corbel</artifactId>
     <version>1.19.0-SNAPSHOT</version>
@@ -41,10 +35,30 @@
         <tag>HEAD</tag>
     </scm>
 
+    <ciManagement>
+        <system>Travis CI</system>
+        <url>https://travis-ci.org/bq/corbel</url>
+    </ciManagement>
+
+    <issueManagement>
+        <url>https://github.com/bq/corbel/issues</url>
+        <system>GitHub Issues</system>
+    </issueManagement>
+
     <properties>
         <appassembler.plugin.version>1.10</appassembler.plugin.version>
         <maven-surefire.plugin.version>2.17</maven-surefire.plugin.version>
         <buildmetadata-maven-plugin.version>1.5.2</buildmetadata-maven-plugin.version>
+        <lib-config.version>0.2.0</lib-config.version>
+        <lib-cli.version>0.3.0-SNAPSHOT</lib-cli.version>
+        <lib-mongodb.version>0.3.0</lib-mongodb.version>
+        <lib-token.version>0.5.0</lib-token.version>
+        <lib-queries.version>0.4.0-SNAPSHOT</lib-queries.version>
+        <lib-ws.version>0.7.0-SNAPSHOT</lib-ws.version>
+        <lib-rabbitmq.version>0.5.0</lib-rabbitmq.version>
+        <spring.version>4.1.2.RELEASE</spring.version>
+        <dropwizard.version>0.7.1</dropwizard.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>
@@ -58,6 +72,45 @@
         <module>restor</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.7</version>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert-core</artifactId>
+            <version>2.0M10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>4.1.2.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -69,6 +122,159 @@
                 <groupId>com.bq.oss.corbel</groupId>
                 <artifactId>rem-api</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>config</artifactId>
+                <version>${lib-config.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>cli</artifactId>
+                <version>${lib-cli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>token</artifactId>
+                <version>${lib-token.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>ws</artifactId>
+                <version>${lib-ws.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>mongodb</artifactId>
+                <version>${lib-mongodb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>queries-api</artifactId>
+                <version>${lib-queries.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>queries-mongo</artifactId>
+                <version>${lib-queries.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bq.oss.lib</groupId>
+                <artifactId>rabbitmq</artifactId>
+                <version>${lib-rabbitmq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-mongodb</artifactId>
+                <version>1.6.1.RELEASE</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>spring-beans</artifactId>
+                        <groupId>org.springframework</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>spring-core</artifactId>
+                        <groupId>org.springframework</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>spring-expression</artifactId>
+                        <groupId>org.springframework</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-redis</artifactId>
+                <version>1.4.1.RELEASE</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>spring-beans</artifactId>
+                        <groupId>org.springframework</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-core</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-auth</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-views</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-assets</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-testing</artifactId>
+                <version>${dropwizard.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.3.6</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>18.0</version>
+            </dependency>
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>2.6.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>mail</artifactId>
+                <version>1.4.7</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -96,6 +302,44 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.2.201409121644</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.redhat.rcm.maven.plugin</groupId>
                 <artifactId>buildmetadata-maven-plugin</artifactId>
@@ -148,15 +392,6 @@
         </profile>
     </profiles>
 
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/bq/corbel</url>
-    </ciManagement>
-
-    <issueManagement>
-        <url>https://github.com/bq/corbel/issues</url>
-        <system>GitHub Issues</system>
-    </issueManagement>
 
     <developers>
         <developer>
@@ -240,4 +475,33 @@
             </roles>
         </developer>
     </developers>
+
+    <distributionManagement>
+        <repository>
+            <id>sonatype-releases</id>
+            <name>Sonatype Nexus releases repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>sonatype</id>
+            <name>Sonatype Nexus snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>sonatype</id>
+            <name>Sonatype Nexus snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+        <repository>
+            <id>sonatype-releases</id>
+            <name>Sonatype Nexus releases repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION
Maven build didn't work for me because it was not able to know where to download the parent pom from.

I believe that the pom hierarchy is just an unnecessary complexity. It is better if everything is self-contained between the Corbel project.

Cheers!
Alex

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bq/corbel/1)
<!-- Reviewable:end -->
