### PR TITLE
Support calling Rem with empty request parameters

### DIFF
--- a/rem-api/src/main/java/com/bq/oss/corbel/resources/rem/request/RequestParameters.java
+++ b/rem-api/src/main/java/com/bq/oss/corbel/resources/rem/request/RequestParameters.java
@@ -1,9 +1,12 @@
 package com.bq.oss.corbel.resources.rem.request;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+import com.sun.jersey.core.util.MultivaluedMapImpl;
 import org.springframework.http.MediaType;
 
 import com.bq.oss.lib.token.TokenInfo;
@@ -14,7 +17,12 @@ import com.bq.oss.lib.token.TokenInfo;
  */
 public interface RequestParameters<E> {
 
+    @Deprecated
     E getApiParameters();
+
+    default Optional<E> getOptionalApiParameters() {
+        return Optional.ofNullable(getApiParameters());
+    }
 
     TokenInfo getTokenInfo();
 
@@ -29,5 +37,51 @@ public interface RequestParameters<E> {
     MultivaluedMap<String, String> getHeaders();
 
     Long getContentLength();
+
+    static <E> RequestParameters<E> emptyParameters() {
+        return new RequestParameters<E>(){
+            @Override
+            public List<MediaType> getAcceptedMediaTypes() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public E getApiParameters() {
+                return null;
+            }
+
+            @Override
+            public TokenInfo getTokenInfo() {
+                return null;
+            }
+
+            @Override
+            public String getCustomParameterValue(String parameterName) {
+                return null;
+            }
+
+            @Override
+            public List<String> getCustomParameterValues(String parameterName) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getParams() {
+                return new MultivaluedMapImpl();
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getHeaders() {
+                return new MultivaluedMapImpl();
+            }
+
+            @Override
+            public Long getContentLength() {
+                return null;
+            }
+        };
+    }
+
+
 
 }

--- a/rem-api/src/main/java/com/bq/oss/corbel/resources/rem/request/RequestParametersImpl.java
+++ b/rem-api/src/main/java/com/bq/oss/corbel/resources/rem/request/RequestParametersImpl.java
@@ -22,7 +22,6 @@ public class RequestParametersImpl<E> implements RequestParameters<E> {
     private final MultivaluedMap<String, String> params;
     private final Long contentLength;
     private final MultivaluedMap<String, String> headers;
-    private static RequestParametersImpl<?> emptyInstance;
 
     public RequestParametersImpl(E apiParameters, TokenInfo tokenInfo, List<MediaType> acceptedMediaTypes, Long contentLength,
             MultivaluedMap<String, String> params, MultivaluedMap<String, String> headers) {
@@ -74,12 +73,5 @@ public class RequestParametersImpl<E> implements RequestParameters<E> {
         return contentLength;
     }
 
-    public static RequestParametersImpl<?> getEmptyInstance() {
-        if (emptyInstance == null) {
-            emptyInstance = new RequestParametersImpl<>(null, null, Collections.<MediaType>emptyList(), null, new MultivaluedMapImpl(),
-                    new MultivaluedMapImpl());
-        }
-        return emptyInstance;
-    }
 
 }

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/dao/MongoResmiDao.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/dao/MongoResmiDao.java
@@ -71,16 +71,16 @@ public class MongoResmiDao implements ResmiDao {
     }
 
     @Override
-    public JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Pagination pagination,
+    public JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination,
             Optional<Sort> sort) {
-        Query query = new MongoResmiQueryBuilder().query(resourceQueries.orElse(null)).pagination(pagination).sort(sort.orElse(null))
+        Query query = new MongoResmiQueryBuilder().query(resourceQueries.orElse(null)).pagination(pagination.orElse(null)).sort(sort.orElse(null))
                 .build();
         LOG.debug("findCollection Query executed : " + query.getQueryObject().toString());
         return JsonUtils.convertToArray(mongoOperations.find(query, JsonObject.class, getMongoCollectionName(uri)));
     }
 
     @Override
-    public JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Pagination pagination,
+    public JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination,
             Optional<Sort> sort) {
         MongoResmiQueryBuilder mongoResmiQueryBuilder = new MongoResmiQueryBuilder();
 
@@ -88,7 +88,7 @@ public class MongoResmiDao implements ResmiDao {
             mongoResmiQueryBuilder.relationDestinationId(uri.getRelationId());
         }
 
-        Query query = mongoResmiQueryBuilder.relationSubjectId(uri).query(resourceQueries.orElse(null)).pagination(pagination)
+        Query query = mongoResmiQueryBuilder.relationSubjectId(uri).query(resourceQueries.orElse(null)).pagination(pagination.orElse(null))
                 .sort(sort.orElse(null)).build();
         query.fields().exclude(_ID).exclude(JsonRelation._SRC_ID);
         LOG.debug("findRelation Query executed : " + query.getQueryObject().toString());

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/dao/ResmiDao.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/dao/ResmiDao.java
@@ -22,9 +22,9 @@ public interface ResmiDao {
 
     JsonObject findResource(ResourceUri uri);
 
-    JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Pagination pagination, Optional<Sort> sort);
+    JsonArray findCollection(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination, Optional<Sort> sort);
 
-    JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Pagination pagination, Optional<Sort> sort);
+    JsonElement findRelation(ResourceUri uri, Optional<List<ResourceQuery>> resourceQueries, Optional<Pagination> pagination, Optional<Sort> sort);
 
     void updateResource(ResourceUri uri, JsonObject entity);
 

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/AbstractResmiRem.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/AbstractResmiRem.java
@@ -50,8 +50,8 @@ public abstract class AbstractResmiRem implements Rem<JsonObject> {
         return new ResourceUri(type, id);
     }
 
-    protected ResourceUri buildRelationUri(String type, String id, String relation, RelationParameters apiParameters) {
-        return new ResourceUri(type, id, relation, apiParameters.getPredicateResource().orElse(null));
+    protected ResourceUri buildRelationUri(String type, String id, String relation,Optional<String> predicateResource) {
+        return new ResourceUri(type, id, relation, predicateResource.orElse(null));
     }
 
     protected Response noContent() {

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiDeleteRem.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiDeleteRem.java
@@ -24,7 +24,7 @@ public class ResmiDeleteRem extends AbstractResmiRem {
     @Override
     public Response collection(String type, RequestParameters<CollectionParameters> parameters, URI uri, Optional<JsonObject> entity) {
         ResourceUri uriResource = buildCollectionUri(type);
-        resmiService.deleteCollection(uriResource, parameters.getApiParameters().getQueries());
+        resmiService.deleteCollection(uriResource, parameters.getOptionalApiParameters().flatMap(params -> params.getQueries()));
         return noContent();
     }
 
@@ -38,7 +38,7 @@ public class ResmiDeleteRem extends AbstractResmiRem {
     @Override
     public Response relation(String type, ResourceId id, String relation, RequestParameters<RelationParameters> parameters,
             Optional<JsonObject> entity) {
-        ResourceUri uri = buildRelationUri(type, id.getId(), relation, parameters.getApiParameters());
+        ResourceUri uri = buildRelationUri(type, id.getId(), relation, parameters.getOptionalApiParameters().flatMap(params -> params.getPredicateResource()));
         if (!id.isWildcard() || uri.getRelationId() != null) {
             resmiService.deleteRelation(uri);
             return noContent();

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiGetRem.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiGetRem.java
@@ -27,10 +27,10 @@ public class ResmiGetRem extends AbstractResmiRem {
     public Response collection(String type, RequestParameters<CollectionParameters> parameters, URI uri, Optional<JsonObject> entity) {
         ResourceUri resourceUri = buildCollectionUri(type);
         try {
-            if (parameters.getApiParameters().getAggregation().isPresent()) {
-                return buildResponse(resmiService.aggregate(resourceUri, parameters.getApiParameters()));
+            if (parameters.getOptionalApiParameters().flatMap(params -> params.getAggregation()).isPresent()) {
+                return buildResponse(resmiService.aggregate(resourceUri, parameters.getOptionalApiParameters().get()));
             } else {
-                return buildResponse(resmiService.findCollection(resourceUri, parameters.getApiParameters()));
+                return buildResponse(resmiService.findCollection(resourceUri, parameters.getOptionalApiParameters()));
             }
 
         } catch (BadConfigurationException bce) {
@@ -49,12 +49,12 @@ public class ResmiGetRem extends AbstractResmiRem {
     @Override
     public Response relation(String type, ResourceId id, String relation, RequestParameters<RelationParameters> parameters,
             Optional<JsonObject> entity) {
-        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getApiParameters());
+        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getOptionalApiParameters().flatMap(params -> params.getPredicateResource()));
         try {
-            if (parameters.getApiParameters().getAggregation().isPresent()) {
-                return buildResponse(resmiService.aggregate(resourceUri, parameters.getApiParameters()));
+            if (parameters.getOptionalApiParameters().flatMap(params -> params.getAggregation()).isPresent()) {
+                return buildResponse(resmiService.aggregate(resourceUri, parameters.getOptionalApiParameters().get()));
             } else {
-                return buildResponse(resmiService.findRelation(resourceUri, parameters.getApiParameters()));
+                return buildResponse(resmiService.findRelation(resourceUri, parameters.getOptionalApiParameters()));
             }
         } catch (Exception e) {
             return ErrorResponseFactory.getInstance().badRequest();

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPostRem.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPostRem.java
@@ -58,7 +58,7 @@ public class ResmiPostRem extends AbstractResmiRem {
             return ErrorResponseFactory.getInstance().methodNotAllowed();
         }
 
-        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getApiParameters());
+        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getOptionalApiParameters().flatMap(params -> params.getPredicateResource()));
 
         try {
             JsonObject requestEntity = entity.orElse(null);

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPutRem.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPutRem.java
@@ -41,7 +41,7 @@ public class ResmiPutRem extends AbstractResmiRem {
         return entity.map(object -> {
             try {
                 Optional<List<ResourceQuery>> conditions = Optional.ofNullable(parameters)
-                        .map(RequestParameters::getApiParameters)
+                        .flatMap(RequestParameters::getOptionalApiParameters)
                         .map(ResourceParameters::getConditions)
                         .orElse(Optional.empty());
                 if (conditions.isPresent()) {
@@ -63,15 +63,15 @@ public class ResmiPutRem extends AbstractResmiRem {
     @Override
     public Response relation(String type, ResourceId id, String relation, RequestParameters<RelationParameters> parameters,
             Optional<JsonObject> entity) {
-        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getApiParameters());
+        ResourceUri resourceUri = buildRelationUri(type, id.getId(), relation, parameters.getOptionalApiParameters().flatMap(params -> params.getPredicateResource()));
 
         if (id.isWildcard()) {
             ErrorResponseFactory.getInstance().methodNotAllowed();
         }
 
-        if (parameters.getApiParameters().getPredicateResource().isPresent()) {
+        if (parameters.getOptionalApiParameters().flatMap(params -> params.getPredicateResource()).isPresent()) {
             try {
-                String uri = URLDecoder.decode(parameters.getApiParameters().getPredicateResource().get(), "UTF-8");
+                String uri = URLDecoder.decode(parameters.getOptionalApiParameters().get().getPredicateResource().get(), "UTF-8");
                 if (JsonRelation.validateUri(uri)) {
 
                     JsonObject requestEntity = entity.orElse(null);

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/service/DefaultResmiService.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/service/DefaultResmiService.java
@@ -100,11 +100,14 @@ public class DefaultResmiService implements ResmiService {
     }
 
     @Override
-    public JsonArray findCollection(ResourceUri uri, CollectionParameters apiParameters) throws BadConfigurationException {
-        if (apiParameters.getSearch().isPresent()) {
-            return findInSearchService(uri, apiParameters);
+    public JsonArray findCollection(ResourceUri uri, Optional<? extends CollectionParameters> apiParameters) throws BadConfigurationException {
+        if (apiParameters.flatMap(params -> params.getSearch()).isPresent()) {
+            return findInSearchService(uri, apiParameters.get());
         } else {
-            return resmiDao.findCollection(uri, apiParameters.getQueries(), apiParameters.getPagination(), apiParameters.getSort());
+            return resmiDao.findCollection(uri,
+                    apiParameters.flatMap(params -> params.getQueries()),
+                    apiParameters.map(params -> params.getPagination()),
+                    apiParameters.flatMap(params -> params.getSort()));
         }
     }
 
@@ -116,7 +119,7 @@ public class DefaultResmiService implements ResmiService {
 
         if (searchObject.isBinded()) {
             CollectionParameters parameters = buildParametersForBinding(apiParameters, searchResult);
-            return findCollection(resourceUri, parameters);
+            return findCollection(resourceUri, Optional.of(parameters));
         } else {
             return searchResult;
         }
@@ -151,11 +154,13 @@ public class DefaultResmiService implements ResmiService {
     }
 
     @Override
-    public JsonElement findRelation(ResourceUri uri, RelationParameters apiParameters) throws BadConfigurationException {
-        if (apiParameters.getSearch().isPresent()) {
-            return findInSearchService(uri, apiParameters);
+    public JsonElement findRelation(ResourceUri uri, Optional<RelationParameters> apiParameters) throws BadConfigurationException {
+        if (apiParameters.flatMap(params -> params.getSearch()).isPresent()) {
+            return findInSearchService(uri, apiParameters.get());
         } else {
-            return resmiDao.findRelation(uri, apiParameters.getQueries(), apiParameters.getPagination(), apiParameters.getSort());
+            return resmiDao.findRelation(uri, apiParameters.flatMap(params -> params.getQueries()),
+                    apiParameters.map(params -> params.getPagination()),
+                    apiParameters.flatMap(params -> params.getSort()));
         }
     }
 

--- a/resmi/src/main/java/com/bq/oss/corbel/resources/rem/service/ResmiService.java
+++ b/resmi/src/main/java/com/bq/oss/corbel/resources/rem/service/ResmiService.java
@@ -26,11 +26,11 @@ public interface ResmiService {
     String ID = "id";
     String _ID = "_id";
 
-    JsonArray findCollection(ResourceUri uri, CollectionParameters apiParameters) throws BadConfigurationException;
+    JsonArray findCollection(ResourceUri uri, Optional<? extends CollectionParameters> apiParameters) throws BadConfigurationException;
 
     JsonObject findResource(ResourceUri uri);
 
-    JsonElement findRelation(ResourceUri uri, RelationParameters apiParameters) throws BadConfigurationException;
+    JsonElement findRelation(ResourceUri uri, Optional<RelationParameters> apiParameters) throws BadConfigurationException;
 
     AggregationResult aggregate(ResourceUri uri, CollectionParameters apiParameters) throws BadConfigurationException;
 

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/dao/MongoResmiDaoTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/dao/MongoResmiDaoTest.java
@@ -100,7 +100,7 @@ public class MongoResmiDaoTest {
                 jsonObjectList);
 
         ResourceUri resourceUri = new ResourceUri(TEST_COLLECTION, TEST_ID, TEST_REL);
-        JsonElement result = mongoResmiDao.findRelation(resourceUri, Optional.empty(), pagination, Optional.empty());
+        JsonElement result = mongoResmiDao.findRelation(resourceUri, Optional.empty(), Optional.of(pagination), Optional.empty());
 
         assertThat(result.isJsonArray()).isTrue();
         assertThat(result.getAsJsonArray().size()).isSameAs(jsonObjectList.size());

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiDeleteRemTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiDeleteRemTest.java
@@ -87,7 +87,7 @@ public class ResmiDeleteRemTest extends ResmiRemTest {
         CollectionParameters collectionParameters = mock(CollectionParameters.class);
 
         when(collectionParameters.getQueries()).thenReturn(optionalQueries);
-        when(parameters.getApiParameters()).thenReturn(collectionParameters);
+        when(parameters.getOptionalApiParameters()).thenReturn(Optional.of(collectionParameters));
 
         Response response = deleteRem.collection(TEST_TYPE, parameters, null, Optional.empty());
         assertThat(response.getStatus()).isEqualTo(204);

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiGetRemTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiGetRemTest.java
@@ -75,9 +75,9 @@ public class ResmiGetRemTest extends ResmiRemTest {
     public void testGetCollection() throws BadConfigurationException {
         ResourceUri resourceUri = new ResourceUri(TEST_TYPE);
         JsonArray jsonArray = new JsonArray();
-        when(resmiServiceMock.findCollection(resourceUri, collectionParametersMock)).thenReturn(jsonArray);
+        when(resmiServiceMock.findCollection(resourceUri, Optional.of(collectionParametersMock))).thenReturn(jsonArray);
 
-        when(requestParametersCollectionParametersMock.getApiParameters()).thenReturn(collectionParametersMock);
+        when(requestParametersCollectionParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(collectionParametersMock));
         when(collectionParametersMock.getAggregation()).thenReturn(Optional.empty());
         when(collectionParametersMock.getQueries()).thenReturn(Optional.ofNullable(Arrays.asList(resourceQueryMock)));
         when(collectionParametersMock.getPagination()).thenReturn(paginationMock);
@@ -92,7 +92,7 @@ public class ResmiGetRemTest extends ResmiRemTest {
     public void testGetCollectionCount() throws BadConfigurationException {
         when(resmiServiceMock.aggregate(new ResourceUri(TEST_TYPE), collectionParametersMock)).thenReturn(countResultMock);
 
-        when(requestParametersCollectionParametersMock.getApiParameters()).thenReturn(collectionParametersMock);
+        when(requestParametersCollectionParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(collectionParametersMock));
         when(collectionParametersMock.getAggregation()).thenReturn(Optional.of(aggregationOperationMock));
         when(aggregationOperationMock.getOperator()).thenReturn(AggregationOperator.$COUNT);
 
@@ -109,7 +109,7 @@ public class ResmiGetRemTest extends ResmiRemTest {
     public void testGetCollectionAverage() throws BadConfigurationException {
         when(resmiServiceMock.aggregate(new ResourceUri(TEST_TYPE), collectionParametersMock)).thenReturn(averageResultMock);
 
-        when(requestParametersCollectionParametersMock.getApiParameters()).thenReturn(collectionParametersMock);
+        when(requestParametersCollectionParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(collectionParametersMock));
         when(collectionParametersMock.getAggregation()).thenReturn(Optional.of(aggregationOperationMock));
         when(aggregationOperationMock.getOperator()).thenReturn(AggregationOperator.$AVG);
 
@@ -128,9 +128,9 @@ public class ResmiGetRemTest extends ResmiRemTest {
         ResourceUri resourceUri = new ResourceUri(TEST_TYPE, ID, TEST_TYPE_RELATION, null);
         ResourceId resourceId = new ResourceId(ID);
 
-        when(resmiServiceMock.findRelation(resourceUri, relationParametersMock)).thenReturn(jsonArray);
+        when(resmiServiceMock.findRelation(resourceUri, Optional.of(relationParametersMock))).thenReturn(jsonArray);
 
-        when(requestParametersRelationParametersMock.getApiParameters()).thenReturn(relationParametersMock);
+        when(requestParametersRelationParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(relationParametersMock));
         when(relationParametersMock.getAggregation()).thenReturn(Optional.empty());
 
         when(relationParametersMock.getQueries()).thenReturn(Optional.ofNullable(Arrays.asList(resourceQueryMock)));
@@ -152,9 +152,9 @@ public class ResmiGetRemTest extends ResmiRemTest {
         ResourceId resourceId = new ResourceId(ID);
 
 
-        when(resmiServiceMock.findRelation(resourceUri, relationParametersMock)).thenReturn(jsonArray);
+        when(resmiServiceMock.findRelation(resourceUri, Optional.of(relationParametersMock))).thenReturn(jsonArray);
 
-        when(requestParametersRelationParametersMock.getApiParameters()).thenReturn(relationParametersMock);
+        when(requestParametersRelationParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(relationParametersMock));
         when(relationParametersMock.getAggregation()).thenReturn(Optional.empty());
 
         when(relationParametersMock.getQueries()).thenReturn(Optional.ofNullable(Arrays.asList(resourceQueryMock)));
@@ -174,7 +174,7 @@ public class ResmiGetRemTest extends ResmiRemTest {
         when(resmiServiceMock.aggregate(new ResourceUri(TEST_TYPE, resourceIdMock.getId(), TEST_TYPE_RELATION), relationParametersMock))
                 .thenReturn(countResultMock);
 
-        when(requestParametersRelationParametersMock.getApiParameters()).thenReturn(relationParametersMock);
+        when(requestParametersRelationParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(relationParametersMock));
         when(relationParametersMock.getAggregation()).thenReturn(Optional.of(aggregationOperationMock));
 
         when(aggregationOperationMock.getOperator()).thenReturn(AggregationOperator.$COUNT);

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPutRemTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiPutRemTest.java
@@ -41,7 +41,7 @@ public class ResmiPutRemTest extends ResmiRemTest {
     private RequestParameters<ResourceParameters> getResourceParametersMockWithCondition(Optional<List<ResourceQuery>> conditions) {
         ResourceParameters resourceParametersMock = mock(ResourceParameters.class);
         RequestParameters<ResourceParameters> requestParametersMock = mock(RequestParameters.class);
-        when(requestParametersMock.getApiParameters()).thenReturn(resourceParametersMock);
+        when(requestParametersMock.getOptionalApiParameters()).thenReturn(Optional.of(resourceParametersMock));
         when(resourceParametersMock.getConditions()).thenReturn(conditions);
         return requestParametersMock;
 

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiRemTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/resmi/ResmiRemTest.java
@@ -59,6 +59,7 @@ public abstract class ResmiRemTest {
         RelationParameters parameters = Mockito.mock(RelationParameters.class);
         when(parameters.getPredicateResource()).thenReturn(optional);
         when(requestParameters.getApiParameters()).thenReturn(parameters);
+        when(requestParameters.getOptionalApiParameters()).thenReturn(Optional.of(parameters));
         return requestParameters;
     }
 

--- a/resmi/src/test/java/com/bq/oss/corbel/resources/rem/service/DefaultResmiServiceTest.java
+++ b/resmi/src/test/java/com/bq/oss/corbel/resources/rem/service/DefaultResmiServiceTest.java
@@ -99,10 +99,10 @@ import com.google.gson.JsonPrimitive;
     public void findTest() throws BadConfigurationException {
         ResourceUri resourceUri = new ResourceUri(TYPE);
         JsonArray fakeResult = new JsonArray();
-        when(resmiDao.findCollection(eq(resourceUri), eq(Optional.of(resourceQueriesMock)), eq(paginationMock), eq(Optional.of(sortMock))))
+        when(resmiDao.findCollection(eq(resourceUri), eq(Optional.of(resourceQueriesMock)), eq(Optional.of(paginationMock)), eq(Optional.of(sortMock))))
                 .thenReturn(fakeResult);
         when(collectionParametersMock.getSearch()).thenReturn(Optional.empty());
-        JsonArray result = defaultResmiService.findCollection(resourceUri, collectionParametersMock);
+        JsonArray result = defaultResmiService.findCollection(resourceUri, Optional.of(collectionParametersMock));
         assertThat(fakeResult).isEqualTo(result);
     }
 
@@ -119,7 +119,7 @@ import com.google.gson.JsonPrimitive;
         when(searchableFieldRegistry.getFieldsFromResourceUri(eq(RESOURCE_URI))).thenReturn(new HashSet(Arrays.asList("t1", "t2")));
         when(resmiSearch.search(eq(RESOURCE_URI), eq(search), any(), eq(PAGE), eq(SIZE))).thenReturn(fakeResult);
 
-        JsonArray result = defaultResmiService.findCollection(resourceUri, collectionParametersMock);
+        JsonArray result = defaultResmiService.findCollection(resourceUri, Optional.of(collectionParametersMock));
         assertThat(fakeResult).isEqualTo(result);
     }
 
@@ -141,12 +141,12 @@ import com.google.gson.JsonPrimitive;
         JsonElement fakeResult = new JsonObject();
         ResourceUri resourceUri = new ResourceUri(TYPE, ID, RELATION_TYPE, "test");
 
-        when(resmiDao.findRelation(eq(resourceUri), eq(Optional.of(resourceQueriesMock)), eq(paginationMock), eq(Optional.of(sortMock))))
+        when(resmiDao.findRelation(eq(resourceUri), eq(Optional.of(resourceQueriesMock)), eq(Optional.of(paginationMock)), eq(Optional.of(sortMock))))
                 .thenReturn(fakeResult);
         when(collectionParametersMock.getSearch()).thenReturn(Optional.empty());
         when(relationParametersMock.getPredicateResource()).thenReturn(Optional.of("test"));
 
-        JsonElement result = defaultResmiService.findRelation(resourceUri, relationParametersMock);
+        JsonElement result = defaultResmiService.findRelation(resourceUri, Optional.of(relationParametersMock));
         assertThat(fakeResult).isEqualTo(result);
     }
 


### PR DESCRIPTION
If you write a REM which uses the RemService to access RESMI outside the context of an HTTP request what RequestParameters should you pass?

This change allows to invoke the REM with an empty parameters without causing a NPE.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bq/corbel/10)
<!-- Reviewable:end -->
